### PR TITLE
Add Dependabot configuration for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '09:00'
+      timezone: 'Asia/Tokyo'
+    labels:
+      - 'dependencies'
+      - 'npm'
+    target-branch: 'main'


### PR DESCRIPTION
Introduce a Dependabot configuration to automate daily updates for npm dependencies on the main branch, scheduled for 09:00 Asia/Tokyo time.